### PR TITLE
Use statevectors with qiskit and qutip instead of density matrices

### DIFF
--- a/iqp_gap/qiskit/test_iqp_gap.py
+++ b/iqp_gap/qiskit/test_iqp_gap.py
@@ -34,10 +34,10 @@ def test_gap(f):
     qr = qiskit.QuantumRegister(N)
     qc = qiskit.QuantumCircuit(qr)
     qc.append(iqp_gap.qiskit.gap(f), qr)
-    qc.save_density_matrix()
-    dm_backend = qiskit.providers.aer.Aer.get_backend("aer_simulator")
-    qc = qiskit.transpile(qc, dm_backend)
-    dm = dm_backend.run(qc).result().data().get("density_matrix")
-    result = np.array(dm)[0, 0]
+    qc.save_statevector()
+    simulator = qiskit.providers.aer.Aer.get_backend("aer_simulator")
+    qc = qiskit.transpile(qc, simulator)
+    sv = simulator.run(qc).result().data().get("statevector")
+    result = sv.probabilities()[0]
     analytical_result = (iqp_gap.gap(f) / 2**N) ** 2
     np.testing.assert_almost_equal(result, analytical_result)

--- a/iqp_gap/qutip/iqp_gap.py
+++ b/iqp_gap/qutip/iqp_gap.py
@@ -25,10 +25,9 @@ def gap(poly):
     >>> _, x, y, z, t = sympy.polys.rings.ring('x, y, z, t', sympy.GF(2))
     >>> qc = gap(x * y + x * z + y * z + x)
     >>> initial_state = qutip.tensor(*(qutip.basis(2, 0) for _ in range(4)))
-    >>> initial_density_matrix = initial_state * initial_state.dag()
     >>> np.testing.assert_almost_equal( \
-            qc.run(initial_density_matrix)[0][0][0], \
-            (8 / 2 ** 4) ** 2 \
+            np.abs(qc.run(initial_state)[0][0]), \
+            8 / 2 ** 4 \
         )
     >>> gap(x + 1)
     Traceback (most recent call last):

--- a/iqp_gap/qutip/test_iqp_gap.py
+++ b/iqp_gap/qutip/test_iqp_gap.py
@@ -34,13 +34,7 @@ def test_gap(f):
     N = f.parent().ngens
     qc = iqp_gap.qutip.gap(f)
     initial_state = qutip.tensor(*(qutip.basis(2, 0) for _ in range(N)))
-    initial_density_matrix = initial_state * initial_state.dag()
-    result_density_matrix = qc.run(initial_density_matrix)
-    result = result_density_matrix
-    while True:
-        try:
-            result = result[0]
-        except IndexError:
-            break
-    analytical_result = (iqp_gap.gap(f) / 2**N) ** 2
+    result_state = qc.run(initial_state)
+    result = np.abs(result_state[0][0][0])
+    analytical_result = np.abs(iqp_gap.gap(f) / 2**N)
     np.testing.assert_almost_equal(result, analytical_result)


### PR DESCRIPTION
We prefer using statevectors to be comparable with what we do with QuEST. (We could have switched everyone to density matrices as well...)